### PR TITLE
Quick Fix for YouTube Shorts

### DIFF
--- a/resources/views/components/youtube-player.blade.php
+++ b/resources/views/components/youtube-player.blade.php
@@ -1,5 +1,12 @@
 @props(['material'])
-
+@php
+    $materialUrl = str($material->url);
+    if ($materialUrl->contains('/shorts/')) {
+        $videoId = $materialUrl->afterLast('/shorts/');
+    } else {
+        $videoId = $materialUrl->afterLast('?v=');
+    }
+@endphp
 <div
     wire:ignore
     x-bind:class="{ 'overflow-hidden rounded-btn aspect-video cursor-pointer': true }"
@@ -10,7 +17,7 @@
     <iframe
         class="size-full"
         loading="lazy"
-        src="https://www.youtube.com/embed/{{ str($material->url)->afterLast('?v=') }}?autoplay=0&controls=0&disablekb=1&playsinline=1&cc_load_policy=1&cc_lang_pref=auto&widget_referrer=https%3A%2F%2Fplyr.io%2F%23youtube&rel=0&showinfo=0&iv_load_policy=3&modestbranding=1&customControls=true&noCookie=false&enablejsapi=1&origin=https%3A%2F%2Fplyr.io&widgetid=1"
+        src="https://www.youtube.com/embed/{{ $videoId }}?autoplay=0&controls=0&disablekb=1&playsinline=1&cc_load_policy=1&cc_lang_pref=auto&widget_referrer=https%3A%2F%2Fplyr.io%2F%23youtube&rel=0&showinfo=0&iv_load_policy=3&modestbranding=1&customControls=true&noCookie=false&enablejsapi=1&origin=https%3A%2F%2Fplyr.io&widgetid=1&ratio=9:16"
         title="{!! $material->title !!}"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
Currently when fetching URLs from a YouTube feed there are 2 URL variants.
Normal Videos: https://www.youtube.com/watch?v=gzKdVsCZiD8
Shorts: https://www.youtube.com/shorts/MQB7r9pEVLI

When building the view component only the normal video URL is accounted for. I've provided a quick fix in the youtube-player view to handle the cases where the video is a short and not a normal format video.
