### PR TITLE
Fix: Embed URL Modification

### DIFF
--- a/app/Data/YoutubeMaterialData.php
+++ b/app/Data/YoutubeMaterialData.php
@@ -16,7 +16,7 @@ class YoutubeMaterialData extends MaterialData
             description: $item->get_enclosure()?->get_description() ?? $item->get_description(),
             body: $item->get_content(),
             author: $item->get_author()?->get_name(),
-            url: str($item->get_link())->replace('shorts/', 'watch?v=')->toString(),
+            url: $item->get_link(),
             publishedAt: Carbon::parse($item->get_date())->timezone(config('app.timezone')),
             feedId: $item->get_id(true),
             imageUrl: $item->get_enclosure()?->get_thumbnail(),

--- a/app/Models/Material.php
+++ b/app/Models/Material.php
@@ -83,17 +83,46 @@ class Material extends Model
     {
         return Attribute::make(
             get: function (): string {
-                if ($this->isArticle()) {
-                    return Uri::of($this->url)
+                return match ($this->source->type) {
+                    SourceType::Article => Uri::of($this->url)
                         ->withQuery([
                             'utm_source' => parse_url(config('app.url'), PHP_URL_HOST),
                             'utm_medium' => 'referral',
                             'utm_campaign' => 'referral',
 
-                        ])->value();
-                }
+                        ])->value(),
+                    default => $this->url,
+                };
+            }
+        )->shouldCache();
+    }
 
-                return $this->url;
+    public function urlForEmbed(): Attribute
+    {
+        return Attribute::make(
+            get: function (): string {
+                return match ($this->source->type) {
+                    SourceType::Youtube => Uri::of('https://www.youtube.com/embed/'.str($this->url)->replace('shorts/', 'watch?v=')->afterLast('?v='))
+                        ->withQuery([
+                            'autoplay' => 0,
+                            'controls' => 0,
+                            'disablekb' => 1,
+                            'playsinline' => 1,
+                            'cc_load_policy' => 1,
+                            'cc_lang_pref' => 'auto',
+                            'widget_referrer' => 'https://plyr.io/#youtube',
+                            'rel' => 0,
+                            'showinfo' => 0,
+                            'iv_load_policy' => 3,
+                            'modestbranding' => 1,
+                            'customControls' => true,
+                            'noCookie' => false,
+                            'enablejsapi' => 1,
+                            'origin' => 'https://plyr.io',
+                            'widgetid' => 1,
+                        ])->value(),
+                    default => $this->url,
+                };
             }
         )->shouldCache();
     }

--- a/resources/views/components/podcast-player.blade.php
+++ b/resources/views/components/podcast-player.blade.php
@@ -50,7 +50,7 @@
                     controls
                     x-on:play.once="$wire.played('{{ $material->slug }}')"
                 >
-                    <source src="{{ $material->url }}" />
+                    <source src="{{ $material->urlForEmbed }}" />
                 </audio>
             </div>
         </div>

--- a/resources/views/components/youtube-player.blade.php
+++ b/resources/views/components/youtube-player.blade.php
@@ -10,7 +10,7 @@
     <iframe
         class="size-full"
         loading="lazy"
-        src="https://www.youtube.com/embed/{{ str($material->url)->afterLast('?v=') }}?autoplay=0&controls=0&disablekb=1&playsinline=1&cc_load_policy=1&cc_lang_pref=auto&widget_referrer=https%3A%2F%2Fplyr.io%2F%23youtube&rel=0&showinfo=0&iv_load_policy=3&modestbranding=1&customControls=true&noCookie=false&enablejsapi=1&origin=https%3A%2F%2Fplyr.io&widgetid=1"
+        src="{{ $material->urlForEmbed }}"
         title="{!! $material->title !!}"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/resources/views/livewire/materials/card.blade.php
+++ b/resources/views/livewire/materials/card.blade.php
@@ -190,25 +190,25 @@
                     <button
                         class="inline-flex"
                         x-on:click="() => {
-                            $dispatch('play-podcast', { 
-                                url: '{{ $material->url }}',
+                            $dispatch('play-podcast', {
+                                url: '{{ $material->urlForEmbed }}',
                                 thumbnail: '{{ $material->thumbnail }}',
                                 publisherName: '{{ $material->source->publisher->name }}',
                                 materialTitle: @js($material->title),
                                 publishedAt: '{{ $material->published_at->inUserTimezone()->toFormattedDateString() }}',
                                 duration: '{{ Carbon\CarbonInterval::seconds($material->duration)->cascade()->forHumans(['short' => true]) }}',
                             });
-                            
+
                             $wire.played();
                         }"
-                        x-show="$store.mainPodcastPlayer.url !== '{{ $material->url }}' || !$store.mainPodcastPlayer.isPlaying"
+                        x-show="$store.mainPodcastPlayer.url !== '{{ $material->urlForEmbed }}' || !$store.mainPodcastPlayer.isPlaying"
                     >
                         <x-heroicon-o-play class="inline-flex size-6 hover:stroke-primary stroke-stone-800 dark:stroke-stone-300" />
                     </button>
                     <button
                         class="inline-flex"
                         x-on:click="$dispatch('pause-podcast')"
-                        x-show="$store.mainPodcastPlayer.url === '{{ $material->url }}' && $store.mainPodcastPlayer.isPlaying"
+                        x-show="$store.mainPodcastPlayer.url === '{{ $material->urlForEmbed }}' && $store.mainPodcastPlayer.isPlaying"
                     >
                         <x-heroicon-o-pause class="inline-flex size-6 hover:stroke-primary stroke-stone-800 dark:stroke-stone-300" />
                     </button>


### PR DESCRIPTION
Revert the modification that changes the YouTube URL before storing in the database, the original URL should persist.
Add `urlForEmbed` attribute to `Material` model to get the embed URL to be used in views.
Modify views that use an embedded player to use the new `urlForEmbed` `Material` model attribute.

This seems to be a cleaner solution. Let me know what you think. :)